### PR TITLE
clean up and print error on refresh fail

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,8 +72,7 @@ else
 				"package/$PKG/refresh" V=s || \
 					exit $?
 
-			git -C "$PATCHES_DIR" diff --quiet -- .
-			if [ $? -ne 0 ]; then
+			if ! git -C "$PATCHES_DIR" diff --quiet -- .; then
 				echo "Dirty patches detected, please refresh and review the diff"
 				git -C "$PATCHES_DIR" checkout -- .
 				exit 1


### PR DESCRIPTION
set -e causes bash to exit right away on cmd failure. So run the command
inside the if statement to get a chance to clean up and print an error
message.

https://superuser.com/a/940542
https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#The-Set-Builtin

Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>