### PR TITLE
Fix feeds.conf

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,10 +15,11 @@ fi
 echo "src-link $FEEDNAME $GITHUB_WORKSPACE/" > feeds.conf
 
 if [ -z "$NO_DEFAULT_FEEDS" ]; then
-	echo 'src-git-full luci https://github.com/openwrt/luci' > feeds.conf
-	echo 'src-git-full routing https://github.com/openwrt/routing' >> feeds.conf
-	echo 'src-git-full packages https://github.com/openwrt/packages' >> feeds.conf
-	echo 'src-git-full telephony https://github.com/openwrt/telephony' >> feeds.conf
+	sed \
+		-e 's,https://git.openwrt.org/feed/,https://github.com/openwrt/,' \
+		-e 's,https://git.openwrt.org/openwrt/,https://github.com/openwrt/,' \
+		-e 's,https://git.openwrt.org/project/,https://github.com/openwrt/,' \
+		feeds.conf.default >> feeds.conf
 fi
 
 #shellcheck disable=SC2153


### PR DESCRIPTION
d29e7cc00b26 introduced a number of issues:

* The `src-link` line for `$GITHUB_WORKSPACE` in feeds.conf is overridden.

* The base feed is missing.

* Any branch/tag/commit information in feeds.conf.default is omitted, i.e. each feed's master branch is always used.

This fixes all of these issues.

Fixes: d29e7cc00b26 ("Use feeds from GH mirror for GH actions")
Signed-off-by: Jeffery To <jeffery.to@gmail.com>