### PR TITLE
Misc fixes for build script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,10 +22,13 @@ fi
 
 echo "src-link $FEEDNAME /feed/" >> feeds.conf
 
+ALL_CUSTOM_FEEDS=
 #shellcheck disable=SC2153
 for EXTRA_FEED in $EXTRA_FEEDS; do
 	echo "$EXTRA_FEED" | tr '|' ' ' >> feeds.conf
+	ALL_CUSTOM_FEEDS+="$(echo "$EXTRA_FEED" | cut -d'|' -f2) "
 done
+ALL_CUSTOM_FEEDS+="$FEEDNAME"
 
 cat feeds.conf
 
@@ -34,7 +37,9 @@ make defconfig > /dev/null
 
 if [ -z "$PACKAGES" ]; then
 	# compile all packages in feed
-	./scripts/feeds install -p "$FEEDNAME" -f -a
+	for FEED in $ALL_CUSTOM_FEEDS; do
+		./scripts/feeds install -p "$FEED" -f -a
+	done
 	make \
 		BUILD_LOG="$BUILD_LOG" \
 		SIGNED_PACKAGES="$SIGNED_PACKAGES" \
@@ -44,7 +49,9 @@ if [ -z "$PACKAGES" ]; then
 else
 	# compile specific packages with checks
 	for PKG in $PACKAGES; do
-		./scripts/feeds install -p "$FEEDNAME" -f "$PKG"
+		for FEED in $ALL_CUSTOM_FEEDS; do
+			./scripts/feeds install -p "$FEED" -f "$PKG"
+		done
 		make \
 			BUILD_LOG="$BUILD_LOG" \
 			IGNORE_ERRORS="$IGNORE_ERRORS" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ make defconfig > /dev/null
 
 if [ -z "$PACKAGES" ]; then
 	# compile all packages in feed
-	./scripts/feeds install -d y -p "$FEEDNAME" -f -a
+	./scripts/feeds install -p "$FEEDNAME" -f -a
 	make \
 		BUILD_LOG="$BUILD_LOG" \
 		SIGNED_PACKAGES="$SIGNED_PACKAGES" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,15 +12,15 @@ if [ -n "$KEY_BUILD" ]; then
 	SIGNED_PACKAGES="y"
 fi
 
-echo "src-link $FEEDNAME /feed/" > feeds.conf
-
 if [ -z "$NO_DEFAULT_FEEDS" ]; then
 	sed \
 		-e 's,https://git.openwrt.org/feed/,https://github.com/openwrt/,' \
 		-e 's,https://git.openwrt.org/openwrt/,https://github.com/openwrt/,' \
 		-e 's,https://git.openwrt.org/project/,https://github.com/openwrt/,' \
-		feeds.conf.default >> feeds.conf
+		feeds.conf.default > feeds.conf
 fi
+
+echo "src-link $FEEDNAME /feed/" >> feeds.conf
 
 #shellcheck disable=SC2153
 for EXTRA_FEED in $EXTRA_FEEDS; do


### PR DESCRIPTION
1. Don't advertise optional features when building
   * `./scripts/feeds install -d y` activates all optional features
     including these default to n in Kconfig, which is undesired in most
     cases.
   * 24b910d72772eda61a07d35bdccdfbf7fd20d133 dropped the switch for
     individual package builds two years ago. Drop it for all-package
     builds as well to ensure consistency and avoid undesired behaviors.
2. Move all custom feeds after default feeds
     * Feeds are downloaded and checked out sequentially. Makefiles from custom
      feeds may include the ones provided by default feeds (e.g. luci.mk), and
      such packages will fail to install without them. Hence, default feeds
      should come before custom feeds.
     * (PS: issue observed with 21.02 but not with 22.03 and snapshot, probably fixed on build system side at some point after 21.02 release)
3. Explicitly install extra feeds
    * Now that packages from extra feeds only get installed when required by
    ones from other feeds, but we might want to directly build them.
