### PR TITLE
Fix build errors, add ARTIFACTS_DIR and FEED_DIR, add CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Test ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - arm_cortex-a15_neon-vfpv4
+          - mips_24kc
+          - x86_64
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Add test directories
+        run: mkdir artifacts feed
+
+      - name: Build
+        uses: ./
+        env:
+          ARCH: ${{ matrix.arch }}-master
+          ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+          FEED_DIR: ${{ github.workspace }}/feed
+          PACKAGES: vim privoxy
+
+      - name: Verify packages saved
+        run: find artifacts/bin/packages/${{ matrix.arch }}/packages/ -maxdepth 1 -name '*.ipk' -type f | grep .
+
+      - name: Verify logs saved
+        run: find artifacts/logs/package/feeds/packages/ -mindepth 2 -maxdepth 2 -name compile.txt -type f | grep .

--- a/README.md
+++ b/README.md
@@ -50,10 +50,14 @@ jobs:
 The action reads a few env variables:
 
 * `ARCH` determines the used OpenWrt SDK Docker container.
+* `ARTIFACTS_DIR` determines where built packages and build logs are saved.
+  Defaults to the default working directory (`GITHUB_WORKSPACE`).
 * `BUILD_LOG` stores build logs in `./logs`.
 * `CONTAINER` can set other SDK containers than `openwrt/sdk`.
 * `EXTRA_FEEDS` are added to the `feeds.conf`, where `|` are replaced by white
   spaces.
+* `FEED_DIR` used in the created `feeds.conf` for the current repo. Defaults to
+  the default working directory (`GITHUB_WORKSPACE`).
 * `FEEDNAME` used in the created `feeds.conf` for the current repo. Defaults to
   `action`.
 * `IGNORE_ERRORS` can ignore failing packages builds.

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,7 @@ author: aparcar
 runs:
   using: 'composite'
   steps:
-    - run: mkdir $GITHUB_WORKSPACE/artifacts
-      shell: bash
-    - run: chmod o+rw $GITHUB_WORKSPACE/artifacts
+    - run: sudo chown -R 1000:1000 $GITHUB_WORKSPACE
       shell: bash
     - run: docker build --build-arg CONTAINER --build-arg ARCH -t sdk $GITHUB_ACTION_PATH
       shell: bash
@@ -28,7 +26,5 @@ runs:
           -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
           sdk
       shell: bash
-    - run: cp -r $GITHUB_WORKSPACE/artifacts/. $GITHUB_WORKSPACE/
-      shell: bash
-    - run: sudo rm -rf $GITHUB_WORKSPACE/artifacts/
+    - run: sudo chown -R --reference=$GITHUB_WORKSPACE/.. $GITHUB_WORKSPACE
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,12 @@ author: aparcar
 runs:
   using: 'composite'
   steps:
-    - run: sudo chown -R 1000:1000 $GITHUB_WORKSPACE
+    - run: |
+        echo "::set-output name=artifacts_dir::${ARTIFACTS_DIR:-$GITHUB_WORKSPACE}"
+        echo "::set-output name=feed_dir::${FEED_DIR:-$GITHUB_WORKSPACE}"
+      shell: bash
+      id: inputs
+    - run: sudo chown -R 1000:1000 ${{ steps.inputs.outputs.artifacts_dir }} ${{ steps.inputs.outputs.feed_dir }}
       shell: bash
     - run: docker build --build-arg CONTAINER --build-arg ARCH -t sdk $GITHUB_ACTION_PATH
       shell: bash
@@ -13,7 +18,6 @@ runs:
           --env BUILD_LOG \
           --env EXTRA_FEEDS \
           --env FEEDNAME \
-          --env GITHUB_WORKSPACE \
           --env IGNORE_ERRORS \
           --env KEY_BUILD \
           --env NO_DEFAULT_FEEDS \
@@ -21,10 +25,11 @@ runs:
           --env NO_SHFMT_CHECK \
           --env PACKAGES \
           --env V \
-          --workdir /github/workspace \
-          -v $(pwd):/github/workspace \
-          -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
+          -v ${{ steps.inputs.outputs.artifacts_dir }}:/artifacts \
+          -v ${{ steps.inputs.outputs.feed_dir }}:/feed \
           sdk
       shell: bash
-    - run: sudo chown -R --reference=$GITHUB_WORKSPACE/.. $GITHUB_WORKSPACE
+    - run: sudo chown -R --reference=${{ steps.inputs.outputs.artifacts_dir }}/.. ${{ steps.inputs.outputs.artifacts_dir }}
+      shell: bash
+    - run: sudo chown -R --reference=${{ steps.inputs.outputs.feed_dir }}/.. ${{ steps.inputs.outputs.feed_dir }}
       shell: bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "$KEY_BUILD" ]; then
 	SIGNED_PACKAGES="y"
 fi
 
-echo "src-link $FEEDNAME $GITHUB_WORKSPACE/" > feeds.conf
+echo "src-link $FEEDNAME /feed/" > feeds.conf
 
 if [ -z "$NO_DEFAULT_FEEDS" ]; then
 	sed \
@@ -72,7 +72,7 @@ else
 			exit 1
 		fi
 
-		PATCHES_DIR=$(find "$GITHUB_WORKSPACE" -path "*/$PKG/patches")
+		PATCHES_DIR=$(find /feed -path "*/$PKG/patches")
 		if [ -d "$PATCHES_DIR" ] && [ -z "$NO_REFRESH_CHECK" ]; then
 			make \
 				BUILD_LOG="$BUILD_LOG" \
@@ -87,7 +87,7 @@ else
 			fi
 		fi
 
-		FILES_DIR=$(find "$GITHUB_WORKSPACE" -path "*/$PKG/files")
+		FILES_DIR=$(find /feed -path "*/$PKG/files")
 		if [ -d "$FILES_DIR" ] && [ -z "$NO_SHFMT_CHECK" ]; then
 			find "$FILES_DIR" -name "*.init" -exec shfmt -w -sr -s '{}' \;
 			if ! git -C "$FILES_DIR" diff --quiet -- .; then
@@ -125,9 +125,9 @@ else
 fi
 
 if [ -d bin/ ]; then
-	mv bin/ "$GITHUB_WORKSPACE/"
+	mv bin/ /artifacts/
 fi
 
 if [ -d logs/ ]; then
-	mv logs/ "$GITHUB_WORKSPACE/"
+	mv logs/ /artifacts/
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,9 +125,9 @@ else
 fi
 
 if [ -d bin/ ]; then
-	mv bin/ "$GITHUB_WORKSPACE/artifacts/"
+	mv bin/ "$GITHUB_WORKSPACE/"
 fi
 
 if [ -d logs/ ]; then
-	mv logs/ "$GITHUB_WORKSPACE/artifacts/"
+	mv logs/ "$GITHUB_WORKSPACE/"
 fi


### PR DESCRIPTION
I debated whether to do so much in one PR, but I think it makes sense to group these:

* Fixed the build error introduced in #9

  Since `refresh` can be called for any package in the repo, the entire directory needs to be writable by the Docker build user.

* Add CI

  So that the results of this PR (and future PRs) can be seen directly. I think more tests can be done, e.g. for the various build options, but I didn't want to make this more complicated that it needs to be for now. (I also chose to test with 3 architectures - in theory only one is necessary, let me know if I should add/remove any.)

* Add `ARTIFACTS_DIR` and `FEED_DIR` environment variables (action inputs)

  This is mainly to support the CI, but it is possible other workflows using this action may want to customize these. I didn't test it directly, but according to GitHub's [documentation](https://docs.github.com/en/actions/learn-github-actions/environment-variables#naming-conventions-for-environment-variables), `GITHUB_WORKSPACE` (and other default environment variables) cannot be overridden (which should mean other workflows cannot set a different `GITHUB_WORKSPACE` when calling this action).