### PR TITLE
Clean package build directory after patch refresh test

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,6 +92,12 @@ else
 				git -C "$PATCHES_DIR" checkout -- .
 				exit 1
 			fi
+
+			make \
+				BUILD_LOG="$BUILD_LOG" \
+				IGNORE_ERRORS="$IGNORE_ERRORS" \
+				"package/$PKG/clean" V=s || \
+					exit $?
 		fi
 
 		FILES_DIR=$(find /feed -path "*/$PKG/files")


### PR DESCRIPTION
Running `refresh` causes quilt to be activated for the package build directory and may interfere with building the package later on. This adds a `clean` after running `refresh`.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>