### PR TITLE
action: replace `set-output` command with environment file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,8 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        echo "::set-output name=artifacts_dir::${ARTIFACTS_DIR:-$GITHUB_WORKSPACE}"
-        echo "::set-output name=feed_dir::${FEED_DIR:-$GITHUB_WORKSPACE}"
+        echo "artifacts_dir=${ARTIFACTS_DIR:-$GITHUB_WORKSPACE}" >> "$GITHUB_OUTPUT"
+        echo "feed_dir=${FEED_DIR:-$GITHUB_WORKSPACE}" >> "$GITHUB_OUTPUT"
       shell: bash
       id: inputs
     - run: sudo chown -R 1000:1000 ${{ steps.inputs.outputs.artifacts_dir }} ${{ steps.inputs.outputs.feed_dir }}


### PR DESCRIPTION
This fixes the `set-output` deprecation warning
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/