### PR TITLE
Allow to sign packages with random keypair

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The action reads a few env variables:
   `action`.
 * `IGNORE_ERRORS` can ignore failing packages builds.
 * `KEY_BUILD` can be a private Signify/`usign` key to sign the packages feed.
+* `SIGNED_PACKAGES` sign the packages feed if set to y. If `KEY_BUILD` is not
+  set, a random keypair will be generated.
 * `NO_DEFAULT_FEEDS` disable adding the default SDK feeds
 * `NO_REFRESH_CHECK` disable check if patches need a refresh.
 * `NO_SHFMT_CHECK` disable check if init files are formated

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,7 @@ runs:
           --env NO_REFRESH_CHECK \
           --env NO_SHFMT_CHECK \
           --env PACKAGES \
+          --env SIGNED_PACKAGES \
           --env V \
           -v ${{ steps.inputs.outputs.artifacts_dir }}:/artifacts \
           -v ${{ steps.inputs.outputs.feed_dir }}:/feed \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,10 @@ BUILD_LOG="${BUILD_LOG:-1}"
 
 cd /home/build/openwrt/
 
+if [ "SIGNED_PACKAGES" = "y" -a -z "$KEY_BUILD" ]; then
+	staging_dir/host/bin/usign -G -s key-build -p key-build.pub -c "Local build key"
+fi
+
 if [ -n "$KEY_BUILD" ]; then
 	echo "$KEY_BUILD" > key-build
 	SIGNED_PACKAGES="y"
@@ -135,6 +139,15 @@ else
 				exit $RET
 			}
 	done
+
+	if [ "SIGNED_PACKAGES" = "y" ]; then
+		make package/index V=s
+		if [ -f "key-build.pub" ]; then
+			fingerprint="$(staging_dir/host/bin/usign -F -p key-build.pub)"
+			mkdir -p /artifacts/pubkey
+			cp key-build.pub "/artifacts/pubkey/$fingerprint"
+		fi
+	fi
 fi
 
 if [ -d bin/ ]; then


### PR DESCRIPTION
Allow to sign packages with random keypair. The generated public key will be stored at `/artifacts/pubkey/` with the name of its fingerprint. By adding local feeds, other CI using this action can install the packages with its dependencies without `opkg update`. It avoids local build packages being incompatible with remote dependencies.

Refs:
https://github.com/openwrt/packages/actions/runs/3470664086/jobs/5799147200

Side topic:
This action used in https://github.com/openwrt/packages/blob/master/.github/workflows/multi-arch-test-build.yml has been broken because of the obsolete rootfs docker. The kernel mods of the test docker has kernel version 5.10.147-1-6ff1f802e677585471e0ec9bdffb624f, but the local build packages require the kernel mods with verison  of 5.15.82-1-95b208ba4178f06f4e9c19b4a217463b. This pr won't fix this issue. It need to update the openwrtorg/rootfs. We should keep sdk version consistent with rootfs.

Refs:
https://github.com/openwrt/packages/actions/runs/3692046677/jobs/6250567274
https://github.com/openwrt/packages/actions/runs/3684361462/jobs/6234006872