### PR TITLE
Add EXTRA_INIT_SCRIPT and EXTRA_SCRIPT_AFTER_UPDATE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,6 @@ The action reads a few env variables:
 * `NO_DEFAULT_FEEDS` disable adding the default SDK feeds
 * `NO_REFRESH_CHECK` disable check if patches need a refresh.
 * `NO_SHFMT_CHECK` disable check if init files are formated
+* `EXTRA_SCRIPT_AFTER_UPDATE` can be used to run additional scripts after the `feeds update` step.
+* `EXTRA_INIT_SCRIPT` can be used to run additional scripts at the beginning of the build process. This is useful for example to install additional packages, like `upx`.
 * `V` changes the build verbosity level.

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ runs:
         docker run --rm \
           --env BUILD_LOG \
           --env EXTRA_FEEDS \
+          --env EXTRA_INIT_SCRIPT \
+          --env EXTRA_SCRIPT_AFTER_UPDATE \
           --env FEEDNAME \
           --env IGNORE_ERRORS \
           --env KEY_BUILD \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -ef
 
+bash -c "$EXTRA_INIT_SCRIPT"
+
 FEEDNAME="${FEEDNAME:-action}"
 BUILD_LOG="${BUILD_LOG:-1}"
 
@@ -33,6 +35,9 @@ ALL_CUSTOM_FEEDS+="$FEEDNAME"
 cat feeds.conf
 
 ./scripts/feeds update -a > /dev/null
+
+bash -c "$EXTRA_SCRIPT_AFTER_UPDATE"
+
 make defconfig > /dev/null
 
 if [ -z "$PACKAGES" ]; then


### PR DESCRIPTION
This PR adds two hook scripts to the entrypoint script, one gives the user an opportunity to add some system package like upx when package dependent host/upx, and another one make use can modify the feeds like golang pkg in [packages](https://github.com/openwrt/packages/tree/master/lang/golang)