### PR TITLE
entrypoint: don't use absolute path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,6 @@ set -ef
 FEEDNAME="${FEEDNAME:-action}"
 BUILD_LOG="${BUILD_LOG:-1}"
 
-cd /home/build/openwrt/
-
 if [ -n "$KEY_BUILD" ]; then
 	echo "$KEY_BUILD" > key-build
 	SIGNED_PACKAGES="y"


### PR DESCRIPTION
The base path of the imagebuilder may change. Just use whatever is set in WORKDIR of the Dockerfile.