### PR TITLE
Dockerfile: use ghcr.io as registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CONTAINER=openwrt/sdk
+ARG CONTAINER=ghcr.io/openwrt/sdk
 ARG ARCH=mips_24kc
 FROM $CONTAINER:$ARCH
 


### PR DESCRIPTION
It's a GitHub action, let's use their servers directly.