### PR TITLE
Install from action feed first

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,13 +20,12 @@ fi
 
 echo "src-link $FEEDNAME /feed/" >> feeds.conf
 
-ALL_CUSTOM_FEEDS=
+ALL_CUSTOM_FEEDS="$FEEDNAME "
 #shellcheck disable=SC2153
 for EXTRA_FEED in $EXTRA_FEEDS; do
 	echo "$EXTRA_FEED" | tr '|' ' ' >> feeds.conf
 	ALL_CUSTOM_FEEDS+="$(echo "$EXTRA_FEED" | cut -d'|' -f2) "
 done
-ALL_CUSTOM_FEEDS+="$FEEDNAME"
 
 cat feeds.conf
 


### PR DESCRIPTION
This PR fixed an issue that if the package is already in the official feed and has an extra feed at the same time, the build script will install from the extra feed first, if the package is not in the extra feed, but in the action feed(the default feed of this action), the script will install from the official build, a real case at https://github.com/EkkoG/openwrt-luci/actions/runs/4776017689/attempts/2

