### PR TITLE
Always return artifacts, group secondary log lines

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,10 @@ runs:
       id: inputs
     - run: sudo chown -R 1000:1000 ${{ steps.inputs.outputs.artifacts_dir }} ${{ steps.inputs.outputs.feed_dir }}
       shell: bash
-    - run: docker build --build-arg CONTAINER --build-arg ARCH -t sdk $GITHUB_ACTION_PATH
+    - run: |
+        echo "::group::  docker build -t sdk $GITHUB_ACTION_PATH"
+        docker build --build-arg CONTAINER --build-arg ARCH -t sdk $GITHUB_ACTION_PATH
+        echo "::endgroup::"
       shell: bash
     - run: |
         docker run --rm \

--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,7 @@ runs:
       shell: bash
     - run: sudo chown -R --reference=${{ steps.inputs.outputs.artifacts_dir }}/.. ${{ steps.inputs.outputs.artifacts_dir }}
       shell: bash
+      if: always()
     - run: sudo chown -R --reference=${{ steps.inputs.outputs.feed_dir }}/.. ${{ steps.inputs.outputs.feed_dir }}
       shell: bash
+      if: always()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,8 +54,7 @@ else
 		make \
 			BUILD_LOG="$BUILD_LOG" \
 			IGNORE_ERRORS="$IGNORE_ERRORS" \
-			"package/$PKG/download" V=s || \
-				exit $?
+			"package/$PKG/download" V=s
 
 		make \
 			BUILD_LOG="$BUILD_LOG" \
@@ -83,8 +82,7 @@ else
 			make \
 				BUILD_LOG="$BUILD_LOG" \
 				IGNORE_ERRORS="$IGNORE_ERRORS" \
-				"package/$PKG/refresh" V=s || \
-					exit $?
+				"package/$PKG/refresh" V=s
 
 			if ! git -C "$PATCHES_DIR" diff --quiet -- .; then
 				echo "Dirty patches detected, please refresh and review the diff"
@@ -95,8 +93,7 @@ else
 			make \
 				BUILD_LOG="$BUILD_LOG" \
 				IGNORE_ERRORS="$IGNORE_ERRORS" \
-				"package/$PKG/clean" V=s || \
-					exit $?
+				"package/$PKG/clean" V=s
 		fi
 
 		FILES_DIR=$(find /feed -path "*/$PKG/files")


### PR DESCRIPTION
"Delay package build error exit, remove -j1 rebuild" is the main commit in this group. Having log files available makes it much easier to diagnose build errors that only occur during CI, e.g. https://github.com/openwrt/packages/pull/22411. Please see the commit message for the full reasoning on removing the rebuild.

On grouping log lines, my preference would have been to group the package build log output as well, but there currently isn't a way to group log lines and have it be expanded by default (for the case of a build error), so this only groups "secondary" log lines.