### PR TITLE
Disable `job summary`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,8 @@ runs:
     -
       name: Build Docker container image
       uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_SUMMARY: false
       with:
         push: false
         tags: sdk


### PR DESCRIPTION
According to [disable-job-summary](https://docs.docker.com/build/ci/github-actions/build-summary/#disable-job-summary), disable it as we don't need this.