### PR TITLE
entrypoint: run setup.sh if existing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,10 @@ endgroup() {
 
 trap 'endgroup' ERR
 
+# snapshot containers don't ship with the SDK to save bandwidth
+# run setup.sh to download and extract the SDK
+[ ! -f setup.sh ] || bash setup.sh
+
 FEEDNAME="${FEEDNAME:-action}"
 BUILD_LOG="${BUILD_LOG:-1}"
 


### PR DESCRIPTION
To save bandwidth, we don't ship daily Docker containers containing ImageBuilder/SDK anymore but instead provide a setup.sh script, downloading the things on demand. This saves a ton of GBs bandwidth and caching is not reasonable for daily builds anyway.

If the setup.sh is found, run it. Stable builds aka any tagged release contains the actual SDK/ImageBuilder, no need to run it there.