### PR TITLE
Support sign apk feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ The action reads a few env variables:
   `action`.
 * `IGNORE_ERRORS` can ignore failing packages builds.
 * `INDEX` makes the action build the package index. Default is 0. Set to 1 to enable.
-* `KEY_BUILD` can be a private Signify/`usign` key to sign the packages feed.
+* `KEY_BUILD` can be a private Signify/`usign` key to sign the packages (ipk) feed.
+* `PRIVATE_KEY` can be a private key to sign the packages (apk) feed.
 * `NO_DEFAULT_FEEDS` disable adding the default SDK feeds
 * `NO_REFRESH_CHECK` disable check if patches need a refresh.
 * `NO_SHFMT_CHECK` disable check if init files are formated

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,7 @@ runs:
           --env FEEDNAME \
           --env IGNORE_ERRORS \
           --env KEY_BUILD \
+          --env PRIVATE_KEY \
           --env NO_DEFAULT_FEEDS \
           --env NO_REFRESH_CHECK \
           --env NO_SHFMT_CHECK \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,11 @@ if [ -n "$KEY_BUILD" ]; then
 	CONFIG_SIGNED_PACKAGES="y"
 fi
 
+if [ -n "$PRIVATE_KEY" ]; then
+	echo "$PRIVATE_KEY" > private-key.pem
+	CONFIG_SIGNED_PACKAGES="y"
+fi
+
 if [ -z "$NO_DEFAULT_FEEDS" ]; then
 	sed \
 		-e 's,https://git.openwrt.org/feed/,https://github.com/openwrt/,' \


### PR DESCRIPTION
Because the upstream switches to APK, we need to support signing the apk packages feed.