### PR TITLE
entypoint: make build optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ runs:
 
     - run: |
         docker run --rm \
+          --env BUILD \
           --env BUILD_LOG \
           --env EXTRA_FEEDS \
           --env FEEDNAME \


### PR DESCRIPTION
Make build optional to enable running package and patch checks on formality failures without doing the heavier build.

Don't hide relevant output under groups. GitHub doesn't allow auto-expanding groups on error.

Fix nonexistent echoes.

Sample runs:
- https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/20081459006/job/57609347923?pr=13#step:7:1
- Failing: https://github.com/GeorgeSapkin/openwrt-packages/actions/runs/20096228869/job/57655254902?pr=13#step:7:5011

Related:
- https://github.com/openwrt/actions-shared-workflows/issues/55#issuecomment-3619641292