### PR TITLE
test: update matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,7 @@ jobs:
       matrix:
         release:
           - master
-          - 24.10.1
-          - 23.05.5
+          - 24.10.4
         arch:
           - aarch64_generic
           - arm_cortex-a15_neon-vfpv4


### PR DESCRIPTION
Remove 23.05 due to it being EOL.

Update 24.10 to 24.10.4.

Link: https://openwrt.org/releases/23.05/notes-23.05.6#openwrt_2305_is_eol