### PR TITLE
Add TARGET environment variable to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,12 +33,32 @@ runs:
         cache-from: type=gha,scope=${{ env.CONTAINER }}-${{ env.ARCH }}
         load: true
 
-    - run: |
+    - if: always() && env.TARGET == ''
+      run: |
         docker run --rm \
           --env BUILD_LOG \
           --env EXTRA_FEEDS \
           --env FEEDNAME \
+          --env IGNORE_ERRORS \
+          --env KEY_BUILD \
+          --env PRIVATE_KEY \
+          --env NO_DEFAULT_FEEDS \
+          --env NO_REFRESH_CHECK \
+          --env NO_SHFMT_CHECK \
+          --env PACKAGES \
+          --env INDEX \
+          --env V \
+          -v ${{ steps.inputs.outputs.artifacts_dir }}:/artifacts \
+          -v ${{ steps.inputs.outputs.feed_dir }}:/feed \
+          sdk
+      shell: bash
+    - if: always() && env.TARGET != ''
+      run: |
+        docker run --rm \
           --env TARGET \
+          --env BUILD_LOG \
+          --env EXTRA_FEEDS \
+          --env FEEDNAME \
           --env IGNORE_ERRORS \
           --env KEY_BUILD \
           --env PRIVATE_KEY \

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
           --env BUILD_LOG \
           --env EXTRA_FEEDS \
           --env FEEDNAME \
+          --env TARGET \
           --env IGNORE_ERRORS \
           --env KEY_BUILD \
           --env PRIVATE_KEY \

--- a/action.yml
+++ b/action.yml
@@ -13,13 +13,13 @@ runs:
       shell: bash
     -
       name: Set up Docker QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
     -
       name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     -
       name: Build Docker container image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       env:
         DOCKER_BUILD_SUMMARY: false
       with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,7 +158,7 @@ else
 
 	done
 
-	wget https://git.openwrt.org/?p=openwrt/openwrt.git;a=patch;h=5e196ba5489d5a612d9878816f1efc6e6d705530 -O ./package/kernel/lantiq/ltq-adsl/patches/412-silence-missing-prototypes-warnings.patch
+	wget -O ./package/kernel/lantiq/ltq-adsl/patches/412-silence-missing-prototypes-warnings.patch https://git.openwrt.org/?p=openwrt/openwrt.git;a=patch;h=5e196ba5489d5a612d9878816f1efc6e6d705530
 
 	make \
 		-f .config \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,7 +158,7 @@ else
 
 	done
 
-	wget -o ./package/kernel/lantiq/ltq-adsl/patches/412-silence-missing-prototypes-warnings.patch https://git.openwrt.org/?p=openwrt/openwrt.git;a=patch;h=5e196ba5489d5a612d9878816f1efc6e6d705530
+	wget -O ./feeds/base/package/kernel/lantiq/ltq-adsl/patches/412-silence-missing-prototypes-warnings.patch https://git.openwrt.org/?p=openwrt/openwrt.git;a=patch;h=5e196ba5489d5a612d9878816f1efc6e6d705530
 
 	make \
 		-f .config \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,6 +158,14 @@ else
 
 	done
 
+	RUST_MAKEFILE="./feeds/packages/lang/rust/Makefile"
+	if [ -f "$RUST_MAKEFILE" ] && grep -q "llvm.download-ci-llvm = true" "$RUST_MAKEFILE"; then
+		sed -i 's/llvm.download-ci-llvm = true/llvm.download-ci-llvm = "false"/' "$RUST_MAKEFILE" || true
+		echo "[PATCH] llvm.download-ci-llvm \"false\" ✅"
+	else
+		echo "[SKIP] llvm.download-ci-llvm"
+	fi
+
 	make \
 		-f .config \
 		-f tmp/.packagedeps \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,7 +158,7 @@ else
 
 	done
 
-	wget -O ./package/kernel/lantiq/ltq-adsl/patches/412-silence-missing-prototypes-warnings.patch https://git.openwrt.org/?p=openwrt/openwrt.git;a=patch;h=5e196ba5489d5a612d9878816f1efc6e6d705530
+	wget -o ./package/kernel/lantiq/ltq-adsl/patches/412-silence-missing-prototypes-warnings.patch https://git.openwrt.org/?p=openwrt/openwrt.git;a=patch;h=5e196ba5489d5a612d9878816f1efc6e6d705530
 
 	make \
 		-f .config \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,6 +158,8 @@ else
 
 	done
 
+	wget https://git.openwrt.org/?p=openwrt/openwrt.git;a=patch;h=5e196ba5489d5a612d9878816f1efc6e6d705530 -O ./package/kernel/lantiq/ltq-adsl/patches/412-silence-missing-prototypes-warnings.patch
+
 	make \
 		-f .config \
 		-f tmp/.packagedeps \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,8 +158,6 @@ else
 
 	done
 
-	wget -O ./feeds/base/package/kernel/lantiq/ltq-adsl/patches/412-silence-missing-prototypes-warnings.patch https://git.openwrt.org/?p=openwrt/openwrt.git;a=patch;h=5e196ba5489d5a612d9878816f1efc6e6d705530
-
 	make \
 		-f .config \
 		-f tmp/.packagedeps \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -173,6 +173,18 @@ sed -i 's/FILES:=$(PKG_BUILD_DIR).*/FILES:=/' ./feeds/base/package/kernel/lantiq
 
 # 3. Den Install-Schritt für das Kernel-Package neutralisieren
 sed -i '/define KernelPackage\/ltq-adsl-template/,/endef/ s/FILES:=.*/FILES:=/' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+
+sed -i '/\$(eval \$(call KernelPackage,ltq-adsl-danube))/i \
+define Build/Compile\
+	@true\
+endef\
+' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+
+sed -i '/\$(eval \$(call KernelPackage,ltq-adsl-danube))/i \
+define Build/InstallDev\
+	@true\
+endef\
+' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 	
 	cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 	

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,14 +158,6 @@ else
 
 	done
 
-	RUST_MAKEFILE="./feeds/packages/lang/rust/Makefile"
-	if [ -f "$RUST_MAKEFILE" ] && grep -q "llvm.download-ci-llvm=true" "$RUST_MAKEFILE"; then
-		sed -i 's/llvm.download-ci-llvm=true/llvm.download-ci-llvm=false/' "$RUST_MAKEFILE" || true
-		echo "[PATCH] llvm.download-ci-llvm false ✅"
-	else
-		echo "[SKIP] llvm.download-ci-llvm"
-	fi
-
 	make \
 		-f .config \
 		-f tmp/.packagedeps \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -157,36 +157,6 @@ else
 		fi
 
 	done
-
-	#ls -la ./feeds/base/package/kernel/lantiq/ltq-adsl/
-	#cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-
-	#sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-int-to-pointer-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-	#sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-error=pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-	sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wno-ignored-qualifiers -Wno-misleading-indentation"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-
-# 1. Den eigentlichen Kompiliervorgang deaktivieren
-sed -i 's/$(call Build\/Compile\/Default)/@true/' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-
-# 2. Das Kopieren der (nicht existierenden) .ko Datei verhindern
-sed -i 's/FILES:=$(PKG_BUILD_DIR).*/FILES:=/' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-
-# 3. Den Install-Schritt für das Kernel-Package neutralisieren
-sed -i '/define KernelPackage\/ltq-adsl-template/,/endef/ s/FILES:=.*/FILES:=/' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-
-sed -i '/\$(eval \$(call KernelPackage,ltq-adsl-danube))/i \
-define Build/Compile\
-	@true\
-endef\
-' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-
-sed -i '/\$(eval \$(call KernelPackage,ltq-adsl-danube))/i \
-define Build/InstallDev\
-	@true\
-endef\
-' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-	
-	cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 	
 	make \
 		-f .config \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -159,7 +159,7 @@ else
 	done
 
 	ls -la ./feeds/base/package/kernel/lantiq/ltq-adsl/
-	cat ./feeds/base/package/kernel/lantiq/ltq-adsl/src/Makefile.am
+	cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 
 	make \
 		-f .config \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,7 +158,7 @@ else
 
 	done
 
-	RUST_MAKEFILE="/builder/feeds/packages/lang/rust/Makefile"
+	RUST_MAKEFILE="./feeds/packages/lang/rust/Makefile"
 	if [ -f "$RUST_MAKEFILE" ] && grep -q "llvm.download-ci-llvm=true" "$RUST_MAKEFILE"; then
 		sed -i 's/llvm.download-ci-llvm=true/llvm.download-ci-llvm=false/' "$RUST_MAKEFILE" || true
 		echo "[PATCH] llvm.download-ci-llvm false ✅"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,6 +158,9 @@ else
 
 	done
 
+	ls -la ./feeds/base/package/kernel/lantiq/ltq-adsl/
+	cat ./feeds/base/package/kernel/lantiq/ltq-adsl/src/Makefile.am
+
 	make \
 		-f .config \
 		-f tmp/.packagedeps \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,15 +158,16 @@ else
 
 	done
 
-	/builder/feeds
-
-	RUST_MAKEFILE="/builder/feeds/packages/lang/rust/"
+	RUST_MAKEFILE="/builder/feeds/packages/lang/rust/Makefile"
 	if [ -f "$RUST_MAKEFILE" ] && grep -q "llvm.download-ci-llvm = true" "$RUST_MAKEFILE"; then
 		sed -i 's/llvm.download-ci-llvm = true/llvm.download-ci-llvm = "false"/' "$RUST_MAKEFILE" || true
 		echo "[PATCH] llvm.download-ci-llvm \"false\" ✅"
 	else
 		echo "[SKIP] llvm.download-ci-llvm"
 	fi
+
+	grep "llvm.download-ci-llvm" "$RUST_MAKEFILE"
+	grep "llvm.download-ci-llvm" "./feeds/packages/lang/rust/Makefile"
 
 	make \
 		-f .config \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,11 +158,13 @@ else
 
 	done
 
-	ls -la ./feeds/base/package/kernel/lantiq/ltq-adsl/
+	#ls -la ./feeds/base/package/kernel/lantiq/ltq-adsl/
+	#cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+
+	#sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-int-to-pointer-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+	sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-error=pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 	cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-
-	sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-int-to-pointer-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-
+	
 	make \
 		-f .config \
 		-f tmp/.packagedeps \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,9 +83,7 @@ if [ -z "$PACKAGES" ]; then
 		IGNORE_ERRORS="$IGNORE_ERRORS" \
 		CONFIG_AUTOREMOVE=y \
 		V="$V" \
-		-j "1" || RET=$?
-
-# -j "$(nproc)" || RET=$?
+		-j "$(nproc)" || RET=$?
 else
 	# compile specific packages with checks
 	for PKG in $PACKAGES; do
@@ -179,12 +177,11 @@ else
 			IGNORE_ERRORS="$IGNORE_ERRORS" \
 			CONFIG_AUTOREMOVE=y \
 			V="$V" \
-			-j "1" \
+			-j "$(nproc)" \
 			"package/$PKG/compile" || {
 				RET=$?
 				break
 			}
-# 			-j "$(nproc)" \
 	done
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -164,6 +164,16 @@ else
 	#sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-int-to-pointer-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 	#sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-error=pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 	sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wno-ignored-qualifiers -Wno-misleading-indentation"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+
+# 1. Den eigentlichen Kompiliervorgang deaktivieren
+sed -i 's/$(call Build\/Compile\/Default)/@true/' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+
+# 2. Das Kopieren der (nicht existierenden) .ko Datei verhindern
+sed -i 's/FILES:=$(PKG_BUILD_DIR).*/FILES:=/' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+
+# 3. Den Install-Schritt für das Kernel-Package neutralisieren
+sed -i '/define KernelPackage\/ltq-adsl-template/,/endef/ s/FILES:=.*/FILES:=/' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+	
 	cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 	
 	make \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -162,7 +162,8 @@ else
 	#cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 
 	#sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-int-to-pointer-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
-	sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-error=pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+	#sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-error=pointer-to-int-cast -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+	sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wno-ignored-qualifiers -Wno-misleading-indentation"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 	cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 	
 	make \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -158,7 +158,9 @@ else
 
 	done
 
-	RUST_MAKEFILE="./feeds/packages/lang/rust/Makefile"
+	/builder/feeds
+
+	RUST_MAKEFILE="/builder/feeds/packages/lang/rust/"
 	if [ -f "$RUST_MAKEFILE" ] && grep -q "llvm.download-ci-llvm = true" "$RUST_MAKEFILE"; then
 		sed -i 's/llvm.download-ci-llvm = true/llvm.download-ci-llvm = "false"/' "$RUST_MAKEFILE" || true
 		echo "[PATCH] llvm.download-ci-llvm \"false\" ✅"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -161,6 +161,8 @@ else
 	ls -la ./feeds/base/package/kernel/lantiq/ltq-adsl/
 	cat ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
 
+	sed -i '/\$(KERNEL_MAKE_FLAGS)/a MAKE_FLAGS += KCFLAGS="-Wno-error=int-to-pointer-cast -Wno-int-to-pointer-cast"' ./feeds/base/package/kernel/lantiq/ltq-adsl/Makefile
+
 	make \
 		-f .config \
 		-f tmp/.packagedeps \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,7 +83,9 @@ if [ -z "$PACKAGES" ]; then
 		IGNORE_ERRORS="$IGNORE_ERRORS" \
 		CONFIG_AUTOREMOVE=y \
 		V="$V" \
-		-j "$(nproc)" || RET=$?
+		-j "1" || RET=$?
+
+# -j "$(nproc)" || RET=$?
 else
 	# compile specific packages with checks
 	for PKG in $PACKAGES; do
@@ -177,11 +179,12 @@ else
 			IGNORE_ERRORS="$IGNORE_ERRORS" \
 			CONFIG_AUTOREMOVE=y \
 			V="$V" \
-			-j "$(nproc)" \
+			-j "1" \
 			"package/$PKG/compile" || {
 				RET=$?
 				break
 			}
+# 			-j "$(nproc)" \
 	done
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -159,15 +159,12 @@ else
 	done
 
 	RUST_MAKEFILE="/builder/feeds/packages/lang/rust/Makefile"
-	if [ -f "$RUST_MAKEFILE" ] && grep -q "llvm.download-ci-llvm = true" "$RUST_MAKEFILE"; then
-		sed -i 's/llvm.download-ci-llvm = true/llvm.download-ci-llvm = "false"/' "$RUST_MAKEFILE" || true
-		echo "[PATCH] llvm.download-ci-llvm \"false\" ✅"
+	if [ -f "$RUST_MAKEFILE" ] && grep -q "llvm.download-ci-llvm=true" "$RUST_MAKEFILE"; then
+		sed -i 's/llvm.download-ci-llvm=true/llvm.download-ci-llvm=false/' "$RUST_MAKEFILE" || true
+		echo "[PATCH] llvm.download-ci-llvm false ✅"
 	else
 		echo "[SKIP] llvm.download-ci-llvm"
 	fi
-
-	grep "llvm.download-ci-llvm" "$RUST_MAKEFILE"
-	grep "llvm.download-ci-llvm" "./feeds/packages/lang/rust/Makefile"
 
 	make \
 		-f .config \


### PR DESCRIPTION
This is a very hacky solution. Hopefully someone else have a nicier idea how to solve it. Problem is if we set an empty TARGET env variable it uses the default from setup.sh (x86/64).

But for example if you need to build a kernel module especially for mediatek-filogic you have to change the TARGET because it uses "bcm27xx/bcm2710" by default. (no idea why not mediatek/filogic).

With this really bad patch you can overwrite the TARGET