### PR TITLE
Added DEFAULT_FEEDS to replace default feeds URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The action reads a few env variables:
 * `KEY_BUILD` can be a private Signify/`usign` key to sign the packages (ipk) feed.
 * `PRIVATE_KEY` can be a private key to sign the packages (apk) feed.
 * `NO_DEFAULT_FEEDS` disable adding the default SDK feeds
+* `DEFAULT_FEEDS` relpace default feeds if `NO_DEFAULT_FEEDS` is disabled, where `|` are replaced by white spaces.
 * `NO_REFRESH_CHECK` disable check if patches need a refresh.
 * `NO_SHFMT_CHECK` disable check if init files are formated
 * `PACKAGES` (Optional) specify the list of packages (space separated) to be built

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,7 @@ runs:
           --env KEY_BUILD \
           --env PRIVATE_KEY \
           --env NO_DEFAULT_FEEDS \
+          --env DEFAULT_FEEDS \
           --env NO_REFRESH_CHECK \
           --env NO_SHFMT_CHECK \
           --env PACKAGES \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,14 @@ if [ -z "$NO_DEFAULT_FEEDS" ]; then
 		-e 's,https://git.openwrt.org/openwrt/,https://github.com/openwrt/,' \
 		-e 's,https://git.openwrt.org/project/,https://github.com/openwrt/,' \
 		feeds.conf.default > feeds.conf
+
+	# Replace complete feed URL when feed name matches (feedname|url^commit format)
+	for DEFAULT_FEED in $DEFAULT_FEEDS; do
+		feed_name=$(echo "$DEFAULT_FEED" | cut -d'|' -f1)
+		feed_url=$(echo "$DEFAULT_FEED" | cut -d'|' -f2)
+		[ -n "$feed_name" ] && [ -n "$feed_url" ] || continue
+		sed -i "s#^\(\([^[:space:]]\+\)[[:space:]]\+\)\(${feed_name}[[:space:]]\+\)\([^[:space:]]\+\)\$#\1\3${feed_url}#" feeds.conf
+	done
 fi
 
 echo "src-link $FEEDNAME /feed/" >> feeds.conf


### PR DESCRIPTION
## DEFAULT_FEEDS feature

Added DEFAULT_FEEDS to replace default feeds URL
e.g. if a newer tag or branch is needed some some reasons.

Adds the possibility to replace the default feeds URL by using:
```
- uses: daxcore/gh-action-sdk@main
  env:
    DEFAULT_FEEDS: packages|https://github.com/openwrt/packages.git^0bcc41f3617e9041513a779a8a54f7fecae1efcd
```
I used it to update rust to higher version and to fix a rust bug not included in current official release:
https://github.com/daxcore/mollysocket-openwrt/blob/main/.github/workflows/build.yml
