### PR TITLE
test: matrix: update OpenWrt 25.12 and 24.10 series

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         release:
           - master
-          - 25.12.3
-          - 24.10.6
+          - 25.12.5
+          - 24.10.7
         arch:
           - aarch64_generic
           - arm_cortex-a15_neon-vfpv4


### PR DESCRIPTION
Release notes:
https://lists.openwrt.org/pipermail/openwrt-announce/2026-May/000086.html
https://lists.openwrt.org/pipermail/openwrt-announce/2026-May/000087.html